### PR TITLE
Fix branch name in CI workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,9 +2,9 @@ name: Docker Slurm
 
 on:
   push:
-    branches: [ devel ]
+    branches: [ main ]
   pull_request:
-    branches: [ devel ]
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
A typo was made in the initial commit of the CI workflow definition.  This fixes the name of the branch for which the CI workflow applies.