### PR TITLE
Add CI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Docker Slurm](https://github.com/NOAA-GSL/DockerSlurmCluster/actions/workflows/docker.yml/badge.svg?branch=main)](https://github.com/NOAA-GSL/DockerSlurmCluster/actions/workflows/docker.yml)
+
 # Slurm Cluster in Ubuntu Docker Images Using Docker Compose
 This is an installation of a Slurm cluster inside Docker.
 


### PR DESCRIPTION
Add a CI badge to the README to indicate status of CI tests on main branch.