### PR TITLE
Add dockerhub push to CI workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -58,7 +58,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: ./frontend
-          file: ./Dockerfile
+          file: ./frontend/Dockerfile
           push: true
           tags: noaagsl/slurm-frontend:latest
           cache-from: type=gha
@@ -69,7 +69,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: ./master
-          file: ./Dockerfile
+          file: ./master/Dockerfile
           push: true
           tags: noaagsl/slurm-master:latest
           cache-from: type=gha
@@ -80,7 +80,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: ./node
-          file: ./Dockerfile
+          file: ./node/Dockerfile
           push: true
           tags: noaagsl/slurm-node:latest
           cache-from: type=gha

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,6 +43,10 @@ jobs:
         run: docker-compose -f docker-compose.yml down
 
       -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      -
         name: Login to Docker Hub
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,3 +41,43 @@ jobs:
       -
         name: Shut down Slurm cluster containers
         run: docker-compose -f docker-compose.yml down
+
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      -
+        name: Build and push frontend
+        uses: docker/build-push-action@v4
+        with:
+          context: ./frontend
+          file: ./Dockerfile
+          push: true
+          tags: noaagsl/slurm-frontend:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      -
+        name: Build and push master
+        uses: docker/build-push-action@v4
+        with:
+          context: ./master
+          file: ./Dockerfile
+          push: true
+          tags: noaagsl/slurm-master:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      -
+        name: Build and push node
+        uses: docker/build-push-action@v4
+        with:
+          context: ./node
+          file: ./Dockerfile
+          push: true
+          tags: noaagsl/slurm-node:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Add the ability for the CI to automatically push the built images to Dockerhub upon successful completion of the Slurm cluster tests.