### PR TITLE
Feature/ssh

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,13 +39,6 @@ jobs:
         run: docker exec slurm-frontend srun hostname
 
       -
-        name: ssh to a Slurm compute node
-        run: |
-          docker exec -it slurm-frontend ssh-keygen -t rsa -f /home/admin/.ssh/id_rsa -N ""
-          docker exec -it slurm-frontend cp /home/admin/.ssh/id_rsa.pub /home/admin/.ssh/authorized_keys
-          docker exec -it slurm-frontend ssh slurmnode1 hostname
-
-      -
         name: Shut down Slurm cluster containers
         run: docker-compose -f docker-compose.yml down
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,5 +39,56 @@ jobs:
         run: docker exec slurm-frontend srun hostname
 
       -
+        name: ssh to a Slurm compute node
+        run: |
+          docker exec -it slurm-frontend ssh-keygen -t rsa -f /home/admin/.ssh/id_rsa -N ""
+          docker exec -it slurm-frontend cp /home/admin/.ssh/id_rsa.pub /home/admin/.ssh/authorized_keys
+          docker exec -it slurm-frontend ssh slurmnode1 hostname
+
+      -
         name: Shut down Slurm cluster containers
         run: docker-compose -f docker-compose.yml down
+
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      -
+        name: Build and push frontend
+        uses: docker/build-push-action@v4
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile
+          push: true
+          tags: noaagsl/slurm-frontend:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      -
+        name: Build and push master
+        uses: docker/build-push-action@v4
+        with:
+          context: ./master
+          file: ./master/Dockerfile
+          push: true
+          tags: noaagsl/slurm-master:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      -
+        name: Build and push node
+        uses: docker/build-push-action@v4
+        with:
+          context: ./node
+          file: ./node/Dockerfile
+          push: true
+          tags: noaagsl/slurm-node:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -49,3 +49,29 @@ To run a Slurm job:
 ```
 docker exec slurm-frontend srun hostname
 ```
+
+# SSH between Slurm cluster nodes
+
+In some instances it may be useful to have the ability
+to ssh to a given Slurm cluster node. Each container
+runs an ssh service to provide this capability. If
+passwordless ssh access to Slurm nodes is required,
+**NEW** ssh keys will need to be generated after the
+cluster is started. For example:
+```
+docker exec -it slurm-frontend ssh-keygen -t rsa -f /home/admin/.ssh/id_rsa -N ""
+docker exec -it slurm-frontend cp /home/admin/.ssh/id_rsa.pub /home/admin/.ssh/authorized_keys
+```
+This will allow you to (for example) ssh from the
+frontend node to the compute nodes:
+```
+admin@slurmfrontend:~$ ssh slurmnode1
+admin@slurmnode1:~$
+```
+
+## WARNING
+
+***ALWAYS GENERATE NEW KEYS AS SHOWN ABOVE*** every
+time a cluster is started. And **NEVER**, under any
+circumstances whatsoever, reuse ssh keys from
+previous cluster instances or from any other source.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,21 +10,32 @@ RUN apt-get update -y && apt-get install -y \
 	
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get install -y \
+    openssh-server \
     slurm-client \
     sudo
     
 RUN useradd -m admin -s /usr/bin/bash -d /home/admin \
-    && echo "admin:admin" | chpasswd \
-    && adduser admin sudo \
-    && echo "admin     ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
- 
+ && echo "admin:admin" | chpasswd \
+ && adduser admin sudo \
+ && echo "admin     ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+RUN mkdir /var/run/sshd \
+ && sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd \
+ && chmod -x /etc/update-motd.d/* \
+ && rm -f /etc/legal
+
+COPY ssh /home/admin/.ssh
+
+RUN chown -R admin:admin /home/admin/.ssh \
+ && chmod -R 700 /home/admin/.ssh
+
 COPY slurm.conf /etc/slurm-llnl/
 COPY cgroup.conf /etc/slurm-llnl/
 COPY docker-entrypoint.sh /etc/slurm-llnl/
 
 WORKDIR /home/admin
 
-EXPOSE 8888
+EXPOSE 22 8888
 
 ENV USER admin
 ENV SHELL bash

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -4,5 +4,6 @@ export SLURM_CPUS_ON_NODE=$(cat /proc/cpuinfo | grep processor | wc -l)
 sudo sed -i "s/REPLACE_IT/CPUs=${SLURM_CPUS_ON_NODE}/g" /etc/slurm-llnl/slurm.conf
 
 sudo service munge start
+sudo service ssh start
 
 tail -f /dev/null

--- a/frontend/ssh/config
+++ b/frontend/ssh/config
@@ -1,0 +1,2 @@
+Host slurmnode* slurmfrontend slurmmaster
+   StrictHostKeyChecking no

--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -9,24 +9,34 @@ RUN apt-get update -y && apt-get install -y \
     wget
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get install -y \
     libpmi2-0-dev \
+    openssh-server \
     slurm-client \
     slurmctld \
     slurmd \
     sudo
 
 RUN useradd -m admin -s /usr/bin/bash -d /home/admin \
-    && echo "admin:admin" | chpasswd \
-    && adduser admin sudo \
-    && echo "admin     ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+ && echo "admin:admin" | chpasswd \
+ && adduser admin sudo \
+ && echo "admin     ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+RUN mkdir /var/run/sshd \
+ && sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd \
+ && chmod -x /etc/update-motd.d/* \
+ && rm -f /etc/legal
+
+COPY ssh /home/admin/.ssh
+
+RUN chown -R admin:admin /home/admin/.ssh \
+ && chmod -R 700 /home/admin/.ssh
 
 COPY slurm.conf /etc/slurm-llnl/
 COPY cgroup.conf /etc/slurm-llnl/
 COPY docker-entrypoint.sh /etc/slurm-llnl/
 
-EXPOSE 6817 6818 6819 3306 
+EXPOSE 22 6817 6818 6819 3306
 
 WORKDIR /home/admin
 

--- a/master/docker-entrypoint.sh
+++ b/master/docker-entrypoint.sh
@@ -5,5 +5,6 @@ sudo sed -i "s/REPLACE_IT/CPUs=${SLURM_CPUS_ON_NODE}/g" /etc/slurm-llnl/slurm.co
 
 sudo service munge start
 sudo service slurmctld start
+sudo service ssh start
 
 tail -f /dev/null

--- a/master/ssh/config
+++ b/master/ssh/config
@@ -1,0 +1,2 @@
+Host slurmnode* slurmfrontend slurmmaster
+   StrictHostKeyChecking no

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -10,19 +10,30 @@ RUN apt-get update -y && apt-get install -y \
     
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get install -y \
+    openssh-server \
     slurm-client \
     slurmd \
     sudo
 
 RUN useradd -m admin -s /usr/bin/bash -d /home/admin \
-    && echo "admin:admin" | chpasswd \
-    && adduser admin sudo \
-    && echo "admin     ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+ && echo "admin:admin" | chpasswd \
+ && adduser admin sudo \
+ && echo "admin     ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
     
+RUN mkdir /var/run/sshd \
+ && sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd \
+ && chmod -x /etc/update-motd.d/* \
+ && rm -f /etc/legal
+
+COPY ssh /home/admin/.ssh
+
+RUN chown -R admin:admin /home/admin/.ssh \
+ && chmod -R 700 /home/admin/.ssh
+
 COPY slurm.conf /etc/slurm-llnl/
 COPY cgroup.conf /etc/slurm-llnl/
 COPY docker-entrypoint.sh /etc/slurm-llnl/
 
-EXPOSE 6817 6818 6819  
+EXPOSE 22 6817 6818 6819
 
 ENTRYPOINT ["/etc/slurm-llnl/docker-entrypoint.sh"]

--- a/node/docker-entrypoint.sh
+++ b/node/docker-entrypoint.sh
@@ -5,5 +5,6 @@ sudo sed -i "s/REPLACE_IT/CPUs=${SLURM_CPUS_ON_NODE}/g" /etc/slurm-llnl/slurm.co
 
 sudo service munge start
 sudo slurmd -N $SLURM_NODENAME
+sudo service ssh start
 
 tail -f /dev/null

--- a/node/ssh/config
+++ b/node/ssh/config
@@ -1,0 +1,2 @@
+Host slurmnode* slurmfrontend slurmmaster
+   StrictHostKeyChecking no


### PR DESCRIPTION
This update adds the support to allow ssh connections between Slurm cluster nodes. This functionality is necessary for certain circumstances such as running [Flux](https://flux-framework.readthedocs.io/en/latest/) instances inside a Slurm allocation. This update adds an openssh-server and basic user config along with documentation describing how to create keys once a cluster is started.