### PR TITLE
Add a CI step to test ssh access

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,6 +39,15 @@ jobs:
         run: docker exec slurm-frontend srun hostname
 
       -
+        name: Test ssh access to Slurm compute nodes
+        run: |
+          ssh-keygen -t rsa -f ~/.ssh/id_rsa -N ""
+          cp ~/.ssh/id_rsa ~/.ssh/authorized_keys
+          timeout 1s ssh slurmnode1 hostname
+          rm -f ~/.ssh/id_rsa*
+          rm -f ~/.ssh/authorized_keys
+
+      -
         name: Shut down Slurm cluster containers
         run: docker-compose -f docker-compose.yml down
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,7 +42,7 @@ jobs:
         name: Test ssh access to Slurm compute nodes
         run: |
           docker exec slurm-frontend ssh-keygen -t rsa -f /home/admin/.ssh/id_rsa -N ""
-          docker exec slurm-frontend cp /home/admin/.ssh/id_rsa /home/admin/.ssh/authorized_keys
+          docker exec slurm-frontend cp /home/admin/.ssh/id_rsa.pub /home/admin/.ssh/authorized_keys
           docker exec slurm-frontend timeout 1s ssh slurmnode1 hostname
           docker exec slurm-frontend rm -f ~/.ssh/id_rsa
           docker exec slurm-frontend rm -f ~/.ssh/id_rsa.pub

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,7 +42,7 @@ jobs:
         name: Test ssh access to Slurm compute nodes
         run: |
           docker exec slurm-frontend ssh-keygen -t rsa -f /home/admin/.ssh/id_rsa -N ""
-          docker exec slurm-frontend cp ~/.ssh/id_rsa ~/.ssh/authorized_keys
+          docker exec slurm-frontend cp /home/admin/.ssh/id_rsa /home/admin/.ssh/authorized_keys
           docker exec slurm-frontend timeout 1s ssh slurmnode1 hostname
           docker exec slurm-frontend rm -f ~/.ssh/id_rsa
           docker exec slurm-frontend rm -f ~/.ssh/id_rsa.pub

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,11 +41,11 @@ jobs:
       -
         name: Test ssh access to Slurm compute nodes
         run: |
-          ssh-keygen -t rsa -f ~/.ssh/id_rsa -N ""
-          cp ~/.ssh/id_rsa ~/.ssh/authorized_keys
-          timeout 1s ssh slurmnode1 hostname
-          rm -f ~/.ssh/id_rsa*
-          rm -f ~/.ssh/authorized_keys
+          docker exec slurm-frontend ssh-keygen -t rsa -f ~/.ssh/id_rsa -N ""
+          docker exec slurm-frontend cp ~/.ssh/id_rsa ~/.ssh/authorized_keys
+          docker exec slurm-frontend timeout 1s ssh slurmnode1 hostname
+          docker exec slurm-frontend rm -f ~/.ssh/id_rsa*
+          docker exec slurm-frontend rm -f ~/.ssh/authorized_keys
 
       -
         name: Shut down Slurm cluster containers

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,10 +41,11 @@ jobs:
       -
         name: Test ssh access to Slurm compute nodes
         run: |
-          docker exec slurm-frontend ssh-keygen -t rsa -f ~/.ssh/id_rsa -N ""
+          docker exec slurm-frontend ssh-keygen -t rsa -f /home/admin/.ssh/id_rsa -N ""
           docker exec slurm-frontend cp ~/.ssh/id_rsa ~/.ssh/authorized_keys
           docker exec slurm-frontend timeout 1s ssh slurmnode1 hostname
-          docker exec slurm-frontend rm -f ~/.ssh/id_rsa*
+          docker exec slurm-frontend rm -f ~/.ssh/id_rsa
+          docker exec slurm-frontend rm -f ~/.ssh/id_rsa.pub
           docker exec slurm-frontend rm -f ~/.ssh/authorized_keys
 
       -


### PR DESCRIPTION
We need the ability to test whether ssh access to Slurm compute nodes works or not.  This adds a CI workflow step that:

1. Creates an ssh key for user admin in /home/admin/.ssh
2. Adds the new key to the admin user's authorized_keys
3. Attempts to run an ssh command to a slurm compute node with a 1 second timeout
4. Removes the ssh key and authorized_keys