### PR TITLE
Add ssh key creation to entrypoint

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,12 +41,9 @@ jobs:
       -
         name: Test ssh access to Slurm compute nodes
         run: |
-          docker exec slurm-frontend ssh-keygen -t rsa -f /home/admin/.ssh/id_rsa -N ""
-          docker exec slurm-frontend cp /home/admin/.ssh/id_rsa.pub /home/admin/.ssh/authorized_keys
           docker exec slurm-frontend timeout 1s ssh slurmnode1 hostname
-          docker exec slurm-frontend rm -f ~/.ssh/id_rsa
-          docker exec slurm-frontend rm -f ~/.ssh/id_rsa.pub
-          docker exec slurm-frontend rm -f ~/.ssh/authorized_keys
+          docker exec slurm-frontend timeout 1s ssh slurmnode2 hostname
+          docker exec slurm-frontend timeout 1s ssh slurmnode3 hostname
 
       -
         name: Shut down Slurm cluster containers

--- a/README.md
+++ b/README.md
@@ -49,29 +49,3 @@ To run a Slurm job:
 ```
 docker exec slurm-frontend srun hostname
 ```
-
-# SSH between Slurm cluster nodes
-
-In some instances it may be useful to have the ability
-to ssh to a given Slurm cluster node. Each container
-runs an ssh service to provide this capability. If
-passwordless ssh access to Slurm nodes is required,
-**NEW** ssh keys will need to be generated after the
-cluster is started. For example:
-```
-docker exec -it slurm-frontend ssh-keygen -t rsa -f /home/admin/.ssh/id_rsa -N ""
-docker exec -it slurm-frontend cp /home/admin/.ssh/id_rsa.pub /home/admin/.ssh/authorized_keys
-```
-This will allow you to (for example) ssh from the
-frontend node to the compute nodes:
-```
-admin@slurmfrontend:~$ ssh slurmnode1
-admin@slurmnode1:~$
-```
-
-## WARNING
-
-***ALWAYS GENERATE NEW KEYS AS SHOWN ABOVE*** every
-time a cluster is started. And **NEVER**, under any
-circumstances whatsoever, reuse ssh keys from
-previous cluster instances or from any other source.

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -6,4 +6,7 @@ sudo sed -i "s/REPLACE_IT/CPUs=${SLURM_CPUS_ON_NODE}/g" /etc/slurm-llnl/slurm.co
 sudo service munge start
 sudo service ssh start
 
+ssh-keygen -t rsa -f /home/admin/.ssh/id_rsa -N ""
+cp /home/admin/.ssh/id_rsa.pub /home/admin/.ssh/authorized_keys
+
 tail -f /dev/null


### PR DESCRIPTION
This makes an ssh key available when the container is started without requiring the key to be stored in a code repository or container registry.  The commands for ssh key generation are added to the container's entry point such that when a container is started, the key is created.  Since the key is only used internally for a given instantiation of the containers, a new key can be generated every time the container is started without any issues.  And since the key is created at run time instead of build time, it is not part of the image, and is not stored anywhere in the repository.  This greatly simplifies use of the container in instances where ssh to compute nodes is needed.  Now the key is created automatically without the user having to know about it or do it.