### PR TITLE
Add multi-platform build for images pushed to registry

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,9 @@ jobs:
       -
         name: Checkout Repository
         uses: actions/checkout@v3
-
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       -
         name: Build and start containers
         run: docker-compose -f docker-compose.yml up --build -d
@@ -65,6 +67,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: ./frontend
+          platforms: linux/amd64,linux/arm64
           file: ./frontend/Dockerfile
           push: true
           tags: noaagsl/slurm-frontend:latest
@@ -76,6 +79,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: ./master
+          platforms: linux/amd64,linux/arm64
           file: ./master/Dockerfile
           push: true
           tags: noaagsl/slurm-master:latest
@@ -87,6 +91,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: ./node
+          platforms: linux/amd64,linux/arm64
           file: ./node/Dockerfile
           push: true
           tags: noaagsl/slurm-node:latest


### PR DESCRIPTION
Using containers on Apple silicon requires support for arm builds of container images.  This adds support for multi-platform images pushed to the registry.