### PR TITLE
Remove unnecessary Slurm packages and cleanup /tmp after install

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,7 @@ jobs:
 
   docker_compose_test:
     name: Docker Compose Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu2204-4c-16g-150ssd
 
     steps:
       -

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,7 @@ jobs:
 
   docker_compose_test:
     name: Docker Compose Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       -
@@ -24,15 +24,15 @@ jobs:
         uses: actions/checkout@v4
       -
         name: Build and start containers
-        run: docker-compose -f docker-compose.yml up --build -d
+        run: docker compose -f docker-compose.yml up --build -d
 
       -
         name: Check cluster logs
-        run: docker-compose -f docker-compose.yml logs
+        run: docker compose -f docker-compose.yml logs
 
       -
         name: Check status of the cluster containers
-        run: docker-compose -f docker-compose.yml ps
+        run: docker compose -f docker-compose.yml ps
 
       -
         name: Check status of Slurm
@@ -51,7 +51,7 @@ jobs:
 
       -
         name: Shut down Slurm cluster containers
-        run: docker-compose -f docker-compose.yml down
+        run: docker compose -f docker-compose.yml down
 
   build-frontend-arm64:
     runs-on: LinuxARM64-4core-16G-150Gb

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,15 +1,13 @@
 FROM ubuntu:22.04
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y && apt-get install -y \
     build-essential \
     git \
     mariadb-server \
     munge \
     vim \
-    wget
-	
-ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get install -y \
+    wget \
     devscripts \
     equivs \
     fakeroot \
@@ -17,9 +15,8 @@ RUN apt-get install -y \
     libdbus-1-dev \
     libhwloc-dev \
     openssh-server \
-    sudo
-
-RUN cd /tmp \
+    sudo \
+ && cd /tmp \
  && wget https://download.schedmd.com/slurm/slurm-23.11.7.tar.bz2 \
  && tar -xaf slurm-23.11.7.tar.bz2 \
  && cd slurm-23.11.7 \
@@ -30,14 +27,10 @@ RUN cd /tmp \
  && dpkg --install slurm-smd_23.11.7-1_${ARCH}.deb \
  && dpkg --install slurm-smd-client_23.11.7-1_${ARCH}.deb \
  && dpkg --install slurm-smd-dev_23.11.7-1_${ARCH}.deb \
- && dpkg --install slurm-smd-doc_23.11.7-1_all.deb \
- && dpkg --install slurm-smd-libnss-slurm_23.11.7-1_${ARCH}.deb \
- && dpkg --install slurm-smd-libpam-slurm-adopt_23.11.7-1_${ARCH}.deb \
  && dpkg --install slurm-smd-libpmi0_23.11.7-1_${ARCH}.deb \
  && dpkg --install slurm-smd-libpmi2-0_23.11.7-1_${ARCH}.deb \
- && dpkg --install slurm-smd-libslurm-perl_23.11.7-1_${ARCH}.deb \
- && dpkg --install slurm-smd-sackd_23.11.7-1_${ARCH}.deb \
- && dpkg --install slurm-smd-sview_23.11.7-1_${ARCH}.deb
+ && rm -rf /tmp/slurm* \
+ && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -m admin -s /usr/bin/bash -d /home/admin \
  && echo "admin:admin" | chpasswd \

--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -1,15 +1,13 @@
 FROM ubuntu:22.04
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y && apt-get install -y \
     build-essential \
     git \
     mariadb-server \
     munge \
     vim \
-    wget
-
-ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get install -y \
+    wget \
     devscripts \
     equivs \
     fakeroot \
@@ -17,9 +15,8 @@ RUN apt-get install -y \
     libdbus-1-dev \
     libhwloc-dev \
     openssh-server \
-    sudo
-
-RUN cd /tmp \
+    sudo \
+ && cd /tmp \
  && wget https://download.schedmd.com/slurm/slurm-23.11.7.tar.bz2 \
  && tar -xaf slurm-23.11.7.tar.bz2 \
  && cd slurm-23.11.7 \
@@ -31,14 +28,10 @@ RUN cd /tmp \
  && dpkg --install slurm-smd-client_23.11.7-1_${ARCH}.deb \
  && dpkg --install slurm-smd-slurmctld_23.11.7-1_${ARCH}.deb \
  && dpkg --install slurm-smd-dev_23.11.7-1_${ARCH}.deb \
- && dpkg --install slurm-smd-doc_23.11.7-1_all.deb \
- && dpkg --install slurm-smd-libnss-slurm_23.11.7-1_${ARCH}.deb \
- && dpkg --install slurm-smd-libpam-slurm-adopt_23.11.7-1_${ARCH}.deb \
  && dpkg --install slurm-smd-libpmi0_23.11.7-1_${ARCH}.deb \
  && dpkg --install slurm-smd-libpmi2-0_23.11.7-1_${ARCH}.deb \
- && dpkg --install slurm-smd-libslurm-perl_23.11.7-1_${ARCH}.deb \
- && dpkg --install slurm-smd-sackd_23.11.7-1_${ARCH}.deb \
- && dpkg --install slurm-smd-sview_23.11.7-1_${ARCH}.deb
+ && rm -rf /tmp/slurm* \
+ && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -m admin -s /usr/bin/bash -d /home/admin \
  && echo "admin:admin" | chpasswd \

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,15 +1,13 @@
 FROM ubuntu:22.04
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y && apt-get install -y \
     build-essential \
     git \
     mariadb-server \
     munge \
     vim \
-    wget
-    
-ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get install -y \
+    wget \
     devscripts \
     equivs \
     fakeroot \
@@ -17,9 +15,8 @@ RUN apt-get install -y \
     libdbus-1-dev \
     libhwloc-dev \
     openssh-server \
-    sudo
-
-RUN cd /tmp \
+    sudo \
+ && cd /tmp \
  && wget https://download.schedmd.com/slurm/slurm-23.11.7.tar.bz2 \
  && tar -xaf slurm-23.11.7.tar.bz2 \
  && cd slurm-23.11.7 \
@@ -31,14 +28,10 @@ RUN cd /tmp \
  && dpkg --install slurm-smd-client_23.11.7-1_${ARCH}.deb \
  && dpkg --install slurm-smd-slurmd_23.11.7-1_${ARCH}.deb \
  && dpkg --install slurm-smd-dev_23.11.7-1_${ARCH}.deb \
- && dpkg --install slurm-smd-doc_23.11.7-1_all.deb \
- && dpkg --install slurm-smd-libnss-slurm_23.11.7-1_${ARCH}.deb \
- && dpkg --install slurm-smd-libpam-slurm-adopt_23.11.7-1_${ARCH}.deb \
  && dpkg --install slurm-smd-libpmi0_23.11.7-1_${ARCH}.deb \
  && dpkg --install slurm-smd-libpmi2-0_23.11.7-1_${ARCH}.deb \
- && dpkg --install slurm-smd-libslurm-perl_23.11.7-1_${ARCH}.deb \
- && dpkg --install slurm-smd-sackd_23.11.7-1_${ARCH}.deb \
- && dpkg --install slurm-smd-sview_23.11.7-1_${ARCH}.deb
+ && rm -rf /tmp/slurm* \
+ && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -m admin -s /usr/bin/bash -d /home/admin \
  && echo "admin:admin" | chpasswd \


### PR DESCRIPTION
This PR trims the container size by removing installation of unnecessary Slurm packages and cleaning up files left in /tmp after the install of Slurm.